### PR TITLE
Cherry-pick resource defaults commits & fix PKI initialisation bug

### DIFF
--- a/api/oc_core_res.c
+++ b/api/oc_core_res.c
@@ -141,6 +141,12 @@ oc_core_encode_interfaces_mask(CborEncoder *parent,
   if (iface_mask & OC_IF_CREATE) {
     oc_rep_add_text_string(if, "oic.if.create");
   }
+  if (iface_mask & OC_IF_STARTUP) {
+    oc_rep_add_text_string(if, "oic.if.startup");
+  }
+  if (iface_mask & OC_IF_STARTUP_REVERT) {
+    oc_rep_add_text_string(if, "oic.if.startup.revert");
+  }
   if (iface_mask & OC_IF_B) {
     oc_rep_add_text_string(if, "oic.if.b");
   }

--- a/api/oc_ri.c
+++ b/api/oc_ri.c
@@ -624,6 +624,8 @@ does_interface_support_method(oc_interface_mask_t iface_mask,
    * supports CREATE, RETRIEVE and UPDATE.
    */
   case OC_IF_A:
+  case OC_IF_STARTUP:
+  case OC_IF_STARTUP_REVERT:
     break;
   }
   return supported;

--- a/api/oc_ri.c
+++ b/api/oc_ri.c
@@ -589,6 +589,10 @@ oc_ri_get_interface_mask(char *iface, size_t if_len)
     iface_mask |= OC_IF_S;
   if (13 == if_len && strncmp(iface, "oic.if.create", if_len) == 0)
     iface_mask |= OC_IF_CREATE;
+  if (14 == if_len && strncmp(iface, "oic.if.startup", if_len) == 0)
+    iface_mask |= OC_IF_STARTUP;
+  if (21 == if_len && strncmp(iface, "oic.if.startup.revert", if_len) == 0)
+    iface_mask |= OC_IF_STARTUP_REVERT;
   return iface_mask;
 }
 

--- a/include/oc_ri.h
+++ b/include/oc_ri.h
@@ -111,7 +111,9 @@ typedef enum {
   OC_IF_RW = 1 << 5,
   OC_IF_A = 1 << 6,
   OC_IF_S = 1 << 7,
-  OC_IF_CREATE = 1 << 8
+  OC_IF_CREATE = 1 << 8,
+  OC_IF_STARTUP = 1 << 9,
+  OC_IF_STARTUP_REVERT = 1 << 10
 } oc_interface_mask_t;
 
 typedef enum {

--- a/messaging/coap/observe.c
+++ b/messaging/coap/observe.c
@@ -171,6 +171,10 @@ get_iface_query(oc_interface_mask_t iface_mask)
     return "if=oic.if.s";
   case OC_IF_CREATE:
     return "if=oic.if.create";
+  case OC_IF_STARTUP:
+    return "if=oic.if.startup";
+  case OC_IF_STARTUP_REVERT:
+    return "if=oic.if.startup.revert";
   default:
     break;
   }

--- a/security/oc_pki.c
+++ b/security/oc_pki.c
@@ -45,6 +45,7 @@ pki_add_intermediate_cert(size_t device, int credid, const unsigned char *cert,
   size_t c_size = cert_size;
   mbedtls_x509_crt int_ca;
   mbedtls_x509_crt_init(&int_ca);
+  int_ca.next = NULL;
   if (oc_certs_is_PEM((const unsigned char *)cert, cert_size) != 0) {
     OC_ERR("provided cert is not in PEM format");
     return -1;
@@ -61,6 +62,7 @@ pki_add_intermediate_cert(size_t device, int credid, const unsigned char *cert,
   OC_DBG("parsed intermediate CA cert");
 
   mbedtls_x509_crt id_cert_chain, *id_cert;
+  id_cert_chain.next = NULL;
   mbedtls_x509_crt_init(&id_cert_chain);
 
   /* Parse the identity cert chain */
@@ -174,6 +176,8 @@ pki_add_identity_cert(size_t device, const unsigned char *cert,
 
   mbedtls_x509_crt cert1, cert2;
   mbedtls_x509_crt_init(&cert1);
+  cert1.next = NULL;
+  cert2.next = NULL;
 
   /* Parse identity cert chain */
   ret = mbedtls_x509_crt_parse(&cert1, (const unsigned char *)cert, c_size);
@@ -266,6 +270,8 @@ pki_add_trust_anchor(size_t device, const unsigned char *cert, size_t cert_size,
 
   mbedtls_x509_crt cert1, cert2;
   mbedtls_x509_crt_init(&cert1);
+  cert1.next = NULL;
+  cert2.next = NULL;
   size_t c_size = cert_size;
 
   /* Parse root cert */

--- a/security/oc_tls.c
+++ b/security/oc_tls.c
@@ -704,6 +704,7 @@ is_known_identity_cert(oc_sec_cred_t *cred)
   /* Identity cert chain currently tracked by mbedTLS */
   mbedtls_x509_crt *id_cert = &certs->cert;
   mbedtls_x509_crt cert_in_cred;
+  cert_in_cred.next = NULL;
   mbedtls_x509_crt *cert = &cert_in_cred;
 next_cred_in_chain:
 


### PR DESCRIPTION
@WAvdBeek As per our earlier discussion, I have cherry-picked the two commits from the BZ2641-ResourceDefaults branch of upstream Iotivity-Lite. There are some other changes which are the solution to the initialization bug I had been hunting for the past week.