### PR TITLE
Automatic building and deployment of Doxygen.

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -23,7 +23,6 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install doxygen
           doxygen --version
-          
           cd tools
 	  ./build_doc.sh
 

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -1,10 +1,13 @@
 name: BuildAndPublishDoxygen
 
-on: [push]
-#   push:
-#     branches:
-#       - master
-# workflow_dispatch:
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 jobs:
   doxygen:

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -23,7 +23,7 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install doxygen
           doxygen --version
-          cd tools
+          cd ${{ github.workspace }}/iotivity-lite/tools
           ./build_doc.sh
 
       - name: copy-docs

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -24,7 +24,7 @@ jobs:
           sudo apt-get install doxygen
           doxygen --version
           cd tools
-	  ./build_doc.sh
+          ./build_doc.sh
 
       - name: copy-docs
         run: |

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -32,7 +32,7 @@ jobs:
           git clone git@github.com:Cascoda/iotivity-lite-doxygen.git
           cd iotivity-lite-doxygen
           rm -rf *
-          cp -r ${{ github.workspace }}/tools/html .
+          cp -r ${{ github.workspace }}/iotivity-lite/tools/html .
           #Rename to "docs"
           mv html docs
           

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -4,7 +4,7 @@ on: [push]
 #   push:
 #     branches:
 #       - master
-  workflow_dispatch:
+# workflow_dispatch:
 
 jobs:
   doxygen:
@@ -25,8 +25,8 @@ jobs:
           doxygen --version
           
           cd tools
-		      ./build_doc.sh
-          
+	  ./build_doc.sh
+
       - name: copy-docs
         run: |
           cd ~/work

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -1,0 +1,47 @@
+name: BuildAndPublishDoxygen
+
+on: [push]
+#   push:
+#     branches:
+#       - master
+  workflow_dispatch:
+
+jobs:
+  doxygen:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: iotivity-lite
+      
+      - uses: webfactory/ssh-agent@v0.5.3
+        with:
+          ssh-private-key: ${{ secrets.IOTIVITY_SSH_KEY }}
+        
+      - name: build-docs
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install doxygen
+          doxygen --version
+          
+          cd tools
+		      ./build_doc.sh
+          
+      - name: copy-docs
+        run: |
+          cd ~/work
+          git clone git@github.com:Cascoda/iotivity-lite-doxygen.git
+          cd iotivity-lite-doxygen
+          rm -rf *
+          cp -r ${{ github.workspace }}/tools/html .
+          #Rename to "docs"
+          mv html docs
+          
+      - name: push-changes
+        run: |
+          cd ~/work/iotivity-lite-doxygen
+          git config --global user.name 'Cascoda Bot'
+          git config --global user.email 'github@cascoda.com'
+          git add .
+          git diff-index --quiet HEAD || git commit -m "Automatic publish from github.com/Cascoda/iotivity-lite"
+          git push

--- a/README.rst
+++ b/README.rst
@@ -45,8 +45,8 @@ api/*
   utility and helper functions to encode/decode
   to/from OCF’s data model, module for encoding and interpreting type 4
   UUIDs, base64 strings, OCF endpoints, and handlers for the discovery, platform
-  and device resources. A complete reference of the Iotivity-Lite API can be found
-  `here <https://cascoda.github.io/iotivity-lite-doxygen/>`_.
+  and device resources. `A complete reference of the Iotivity-Lite API can be found
+  here <https://cascoda.github.io/iotivity-lite-doxygen/>`_.
 
 messaging/coap/*
   contains a tailored CoAP implementation.

--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,8 @@ api/*
   utility and helper functions to encode/decode
   to/from OCF’s data model, module for encoding and interpreting type 4
   UUIDs, base64 strings, OCF endpoints, and handlers for the discovery, platform
-  and device resources.
+  and device resources. A complete reference of the Iotivity-Lite API can be found
+  `here <https://cascoda.github.io/iotivity-lite-doxygen/>`_.
 
 messaging/coap/*
   contains a tailored CoAP implementation.


### PR DESCRIPTION
Resolves Cascoda/cascoda-sdk-priv#527

Also added in the main README the link of where the doxygen documentation is hosted.